### PR TITLE
Fix setting on callbacks

### DIFF
--- a/src/Native/Phoenix.js
+++ b/src/Native/Phoenix.js
@@ -113,22 +113,25 @@ Elm.Native.Phoenix.make = function(localRuntime) {
 		var on = options.on;
 		while (on.ctor !== '[]') {
 			var hook = on._0;
-			channel.on(hook.event, function(msg) {
-				var response = hook.callback(msg);
-				switch (response.ctor) {
-					case 'Ignore':
-					  break;
-					case 'Leave':
-					  channel.leave();
-						break;
-					case 'SendMessage':
-					  Signal.sendMessage(response._0);
-					  break;
-					case "PerformTask":
-            Task.perform(response._0);
-            break;
+			function handler(hook) {
+				return function(msg) {
+					var response = hook.callback(msg);
+					switch (response.ctor) {
+						case 'Ignore':
+							break;
+						case 'Leave':
+							channel.leave();
+							break;
+						case 'SendMessage':
+							Signal.sendMessage(response._0);
+							break;
+						case "PerformTask":
+							Task.perform(response._0);
+							break;
+					}
 				}
-			});
+			}
+			channel.on(hook.event, handler(hook));
 			on = on._1;
     }
 		return channel;


### PR DESCRIPTION
This fixes bug where all ```channel.on``` callbacks would call last set `hook.callback`.

Example:
```Elm
join : String -> Socket -> Task x Channel
join topic socket =
  Phoenix.Channel.channel topic socket
  |> Phoenix.Channel.on "new:msg" newMessage
  |> Phoenix.Channel.on "user:entered" newUser
  |> Phoenix.Channel.join                      
```

On event `"user:entered"` `newMessage` callback was called with previous version of code. `on` hooks list is reversed because of prepending in `Channel.elm on` function. That made "new:msg" event was last one that was processed in while loop. And because of how JavaScript closures work `hook` variable was captured in anonymous function. `while` loop was changing hook variable and so it also changed in previously captured closures.  